### PR TITLE
Don't crash if the linked user is not in the admin

### DIFF
--- a/src/auditlog/mixins.py
+++ b/src/auditlog/mixins.py
@@ -20,7 +20,10 @@ class LogEntryAdminMixin(object):
         if obj.actor:
             app_label, model = settings.AUTH_USER_MODEL.split('.')
             viewname = 'admin:%s_%s_change' % (app_label, model.lower())
-            link = urlresolvers.reverse(viewname, args=[obj.actor.id])
+            try:
+                link = urlresolvers.reverse(viewname, args=[obj.actor.id])
+            except NoReverseMatch:
+                return u'%s' % (obj.actor)
             return u'<a href="%s">%s</a>' % (link, obj.actor)
 
         return 'system'


### PR DESCRIPTION
Related to issue #99, for the case when the User model is not enabled in admin.